### PR TITLE
chore($installation): add bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "client/bower_components/",
+  "timeout": 120000
+}


### PR DESCRIPTION
In linux system, bower by default install bower components in the same directory as bower.json.
This will break the installation process for our repo
